### PR TITLE
Adjust autoload path definition

### DIFF
--- a/seriously-simple-stats.php
+++ b/seriously-simple-stats.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use SeriouslySimpleStats\Classes\Stats;
 
-require_once 'vendor/autoload.php';
+require_once __DIR__ . 'vendor/autoload.php';
 
 define( 'SSP_STATS_VERSION', '1.2.4' );
 define( 'SSP_STATS_DIR_PATH', trailingslashit( plugin_dir_path( __FILE__ ) ) );


### PR DESCRIPTION
I found that with Docker and some hosts that having this extra definition around paths allowed the plugin to load, I was getting errors about path not found prior to this adjustment.