### PR TITLE
Fix google undefined error

### DIFF
--- a/php/classes/class-ssp-stats.php
+++ b/php/classes/class-ssp-stats.php
@@ -1025,8 +1025,11 @@ class Stats {
 	 */
 	public function admin_enqueue_scripts ( $hook = '' ) {
 
-		//index.php added to accommodate dashboard widget chart
-		if( 'podcast_page_podcast_stats' == $hook || 'index.php' == $hook ) {
+		global $typenow;
+
+		// index.php added to accommodate dashboard widget chart
+		// 'podcast' == $typenow added to serve right side panel with podcast stats in podcast edition mode
+		if( 'podcast_page_podcast_stats' === $hook || 'index.php' === $hook || 'podcast' === $typenow ) {
 
 			// Include Google Charts scripts
 			wp_enqueue_script( 'google-charts', "//www.google.com/jsapi?autoload={'modules':[{'name':'visualization','version':'1','packages':['corechart']}]}", array(), $this->_version, false );

--- a/php/classes/class-ssp-stats.php
+++ b/php/classes/class-ssp-stats.php
@@ -925,7 +925,7 @@ class Stats {
 	 */
 	private function generate_chart ( $type = '', $title = '', $columns = array(), $data = array(), $target = '', $height = 400, $width = '100%' ) {
 
-		if( ! $type || ! $target || ! is_array( $columns )  || ! is_array( $data ) ) {
+		if( ! $type || ! $target || ! is_array( $columns )  || ! is_array( $data ) || ! wp_script_is( 'google-charts' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes: https://wordpress.org/support/topic/javascript-error-google-is-not-defined-2/
I've encountered the same error in a JavaScript console recently.

- added podcast post type edition mode to enqueue `google-charts` script
- changed `$hook` comparison signs to more strict `===` (instead of actual `==` that can give some false positives due to PHP dynamic variables typing / casting)
:point_right: https://www.php.net/manual/en/types.comparisons.php
- added checking the `google-charts` script handle presence among enqueued scripts before generating a chart via `generate_chart()` method

I've looked through the codebase for the usages of this problematic piece of code and tested it as well on my WordPress installation and everything seems OK now.

Thanks for a good plugin! :+1: 