### PR TITLE
Feature/reorder user agent check

### DIFF
--- a/php/classes/class-ssp-stats-hit.php
+++ b/php/classes/class-ssp-stats-hit.php
@@ -124,17 +124,17 @@ class Stats_Hit {
 			$referrer = 'overcast';
 		} else if ( stripos( $user_agent, 'Pocket Casts' ) !== false ) {
 			$referrer = 'pocketcasts';
-		} else if ( stripos( $user_agent, 'Android' ) !== false ) {
-			$referrer = 'android';
 		} else if ( stripos( $user_agent, 'PodcastAddict' ) !== false ) {
 			$referrer = 'podcast_addict';
 		} else if ( stripos( $user_agent, 'Player FM' ) !== false ) {
 			$referrer = 'playerfm';
 		} else if ( stripos( $user_agent, 'Google-Play' ) !== false ) {
 			$referrer = 'google_play';
+		} else if ( stripos( $user_agent, 'Android' ) !== false ) {
+			$referrer = 'android';
 		}
 
-		// Get episode ID for database insert
+        // Get episode ID for database insert
 		$episode_id = $episode->ID;
 
 		// Get remote client IP address

--- a/php/classes/class-ssp-stats-hit.php
+++ b/php/classes/class-ssp-stats-hit.php
@@ -134,7 +134,7 @@ class Stats_Hit {
 			$referrer = 'android';
 		}
 
-        // Get episode ID for database insert
+		// Get episode ID for database insert
 		$episode_id = $episode->ID;
 
 		// Get remote client IP address


### PR DESCRIPTION
Fixes #83 

Moves the "Android" check to the bottom of the list, for user agent strings that might contain Android, but are for other platforms, ie PodcastAddict.