### PR TITLE
Use absolute require file paths

### DIFF
--- a/seriously-simple-stats.php
+++ b/seriously-simple-stats.php
@@ -27,13 +27,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use SeriouslySimpleStats\Classes\Stats;
 
-require_once 'vendor/autoload.php';
-
 define( 'SSP_STATS_VERSION', '1.3.0' );
 define( 'SSP_STATS_DIR_PATH', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 
+require_once SSP_STATS_DIR_PATH . 'vendor/autoload.php';
+
 if ( ! function_exists( 'is_ssp_active' ) ) {
-	require_once 'ssp-includes/ssp-functions.php';
+	require_once SSP_STATS_DIR_PATH . 'ssp-includes/ssp-functions.php';
 }
 
 if ( is_ssp_active( '1.13.1' ) ) {


### PR DESCRIPTION
If a WordPress install has a `ABSPATH . 'vendor/autoload.php'` file, that will be included here instead of `__DIR__ . 'vendor/autoload.php'`, ultimately causing a PHP fatal error.

This is because PHP resolves relative paths relative to the current working directory (which is the web entry point at `ABSPATH . 'index.php'`) first before trying the current directory.

Eg, in this case, `realpath( 'vendor/autoload.php' )` returns `/home/example.org/public_html/vendor/autoload.php`.